### PR TITLE
bugfix: oneline-comment in css, xml, html (#1)

### DIFF
--- a/src/commentBox.ts
+++ b/src/commentBox.ts
@@ -81,7 +81,15 @@ export class commentBox{
 			return undefined;
 		}
 
-		const cursor = editor.selection.active;
+		let cursor = editor.selection.active;
+
+		if(cursor.character > 0){
+			const prevCursor = new vscode.Position(cursor.line, cursor.character - 1);
+			const currentChar = editor.document.getText(new vscode.Range(prevCursor, cursor));
+			if(currentChar == " "){
+				cursor = prevCursor;
+			}
+		}
 
 		if(this.isGeneratingOneline(editor.document, cursor) && this.enableOneline){
 			const completion = new vscode.CompletionItem("Generate oneline comment", vscode.CompletionItemKind.Function);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,11 +68,21 @@ export function activate(context: vscode.ExtensionContext) {
 		{provideCompletionItems: generator.provideCompletionItems.bind(generator)},
 		generator.getOnelineSnippet().substring(generator.getOnelineSnippet().length - 1, generator.getOnelineSnippet().length)
 	);
+	const oneLineProviderWithSpace = vscode.languages.registerCompletionItemProvider(
+		{ scheme: 'file'},
+		{provideCompletionItems: generator.provideCompletionItems.bind(generator)},
+		" "
+	);
 
 	const boxedProvider = vscode.languages.registerCompletionItemProvider(
 		{ scheme: 'file'},
 		{provideCompletionItems: generator.provideCompletionItems.bind(generator)},
 		generator.getBoxedSnippet().substring(generator.getBoxedSnippet().length - 1, generator.getBoxedSnippet().length)
+	);
+	const boxedProviderWithSpace = vscode.languages.registerCompletionItemProvider(
+		{ scheme: 'file'},
+		{provideCompletionItems: generator.provideCompletionItems.bind(generator)},
+		" "
 	);
 
 
@@ -83,5 +93,7 @@ export function activate(context: vscode.ExtensionContext) {
 	
 	context.subscriptions.push(disposable);
 	context.subscriptions.push(oneLineProvider);
+	context.subscriptions.push(oneLineProviderWithSpace);
 	context.subscriptions.push(boxedProvider);
+	context.subscriptions.push(boxedProviderWithSpace);
 }


### PR DESCRIPTION
- snippet直後に空白スペースを置いた場合でも補完候補を表示させる